### PR TITLE
fixes #49, perl script is splitting url field on comma, which is a legal url character

### DIFF
--- a/tools/cna-assignment-info-to-json.pl
+++ b/tools/cna-assignment-info-to-json.pl
@@ -101,7 +101,7 @@ while (@lines)
     $product = $fields[1];
     $version = $fields[2];
     $problem_type = $fields[3];
-    push(@urls, split(/\s*,\s*/, $fields[4]));
+    push(@urls, split(/\s+/, $fields[4]));
     $description = $fields[5];
   }
   else


### PR DESCRIPTION
cna-assignment-info-to-json.pl is splitting the url field using commas (so commas within a CSV file's field), which is inherently adventurous https://github.com/CVEProject/automation-working-group/blob/master/tools/cna-assignment-info-to-json.pl#L104, but more importantly, commas are valid URL characters https://tools.ietf.org/html/rfc3986#section-2, so the perl script could produce json files where one URL is incorrectly split into 2 ore more URLs. Suggest whitespace as the internal field separator since it's one of the few illegal characters.

I can confirm that this change fixes the problem, but I realize many other people may not be expecting this change so it may require some coordination.