### PR TITLE
- Updated to support RESERVED and REJECT states as well as PUBLIC.

### DIFF
--- a/cve_json_schema/CVE_JSON_4.0_min.schema
+++ b/cve_json_schema/CVE_JSON_4.0_min.schema
@@ -1,4 +1,5 @@
 {
+  "description": "Schema to validate minimal structure needed for CVE",
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "definitions": {
@@ -56,43 +57,48 @@
   },
 
   "type": "object",
-  "required": [ "data_type", "data_format", "data_version", "CVE_data_meta", "affects", "problemtype", "references", "description" ],
-  "properties": {
-    "data_type": { "enum": [ "CVE" ] },
-    "data_format": { "enum": [ "MITRE" ] },
-    "data_version": { "enum": [ "4.0" ] },
-    "CVE_data_meta": {
-      "type":"object",
-      "required": [ "ID", "ASSIGNER" ],
-      "properties": { 
-        "ID": { "$ref": "#/definitions/cve_id" },
-        "ASSIGNER": { "$ref": "#/definitions/email_address" }
-      }
-    },
-    "affects": {
-      "type": "object",
-      "required": [ "vendor" ],
+  "oneOf": [
+    {
+      "required": [ "data_type", "data_format", "data_version", "CVE_data_meta", "affects", "problemtype", "references", "description" ],
       "properties": {
-        "vendor": {
+        "data_type": { "enum": [ "CVE" ] },
+        "data_format": { "enum": [ "MITRE" ] },
+        "data_version": { "enum": [ "4.0" ] },
+        "CVE_data_meta": {
+          "type":"object",
+          "required": [ "ID", "ASSIGNER" ],
+          "properties": { 
+            "ID": { "$ref": "#/definitions/cve_id" },
+            "ASSIGNER": { "$ref": "#/definitions/email_address" },
+            "STATE": { "enum": [ "PUBLIC" ] }
+          }
+        },
+        "affects": {
           "type": "object",
-          "required": [ "vendor_data" ],
+          "required": [ "vendor" ],
           "properties": {
-            "vendor_data": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "required": [ "vendor_name", "product" ],
-                "properties": {
-                  "vendor_name": { "type": "string" },
-                  "product": {
+            "vendor": {
+              "type": "object",
+              "required": [ "vendor_data" ],
+              "properties": {
+                "vendor_data": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
                     "type": "object",
-                    "required": [ "product_data" ],
+                    "required": [ "vendor_name", "product" ],
                     "properties": {
-                      "product_data": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": { "$ref": "#/definitions/product" }
+                      "vendor_name": { "type": "string" },
+                      "product": {
+                        "type": "object",
+                        "required": [ "product_data" ],
+                        "properties": {
+                          "product_data": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": { "$ref": "#/definitions/product" }
+                          }
+                        }
                       }
                     }
                   }
@@ -100,53 +106,126 @@
               }
             }
           }
-        }
-      }
-    },
-    "problemtype": {
-      "type": "object",
-      "required": [ "problemtype_data" ],
-      "properties": {
-        "problemtype_data": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "required": [ "description" ],
-            "properties": {
-              "description": {
-                "type": "array",
-                "minItems": 1,
-                "items": { "$ref": "#/definitions/lang_string" }
+        },
+        "problemtype": {
+          "type": "object",
+          "required": [ "problemtype_data" ],
+          "properties": {
+            "problemtype_data": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [ "description" ],
+                "properties": {
+                  "description": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "$ref": "#/definitions/lang_string" }
+                  }
+                }
               }
+            }
+          }
+        },
+        "references": {
+          "type": "object",
+          "required": [ "reference_data" ],
+          "properties": {
+            "reference_data": {
+              "type": "array",
+              "maxItems": 500,
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/reference" }
+            }
+          }
+        },
+        "description": {
+          "type": "object",
+          "required": [ "description_data" ],
+          "properties": {
+            "description_data": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/lang_string" }
             }
           }
         }
       }
     },
-    "references": {
-      "type": "object",
-      "required": [ "reference_data" ],
+    {
+      "required": [ "data_type", "data_format", "data_version", "CVE_data_meta", "description" ],
       "properties": {
-        "reference_data": {
-          "type": "array",
-          "maxItems": 500,
-          "minItems": 1,
-          "items": { "$ref": "#/definitions/reference" }
+        "data_type": { "enum": [ "CVE" ] },
+        "data_format": { "enum": [ "MITRE" ] },
+        "data_version": { "enum": [ "4.0" ] },
+        "CVE_data_meta": {
+          "type":"object",
+          "required": [ "ID", "ASSIGNER" ],
+          "properties": { 
+            "ID": { "$ref": "#/definitions/cve_id" },
+            "ASSIGNER": { "$ref": "#/definitions/email_address" },
+            "STATE": { "enum": [ "RESERVED" ] }
+          }
+        },
+        "affects": {
+          "not": {}
+        },
+        "description": {
+          "type": "object",
+          "required": [ "description_data" ],
+          "properties": {
+            "description_data": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/lang_string" }
+            }
+          }
+        },
+        "problemtype": {
+          "not": {}
+        },
+        "references": {
+          "not": {}
         }
       }
     },
-    "description": {
-      "type": "object",
-      "required": [ "description_data" ],
+    {
+      "required": [ "data_type", "data_format", "data_version", "CVE_data_meta", "description" ],
       "properties": {
-        "description_data": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/definitions/lang_string" }
+        "data_type": { "enum": [ "CVE" ] },
+        "data_format": { "enum": [ "MITRE" ] },
+        "data_version": { "enum": [ "4.0" ] },
+        "CVE_data_meta": {
+          "type":"object",
+          "required": [ "ID", "ASSIGNER" ],
+          "properties": { 
+            "ID": { "$ref": "#/definitions/cve_id" },
+            "ASSIGNER": { "$ref": "#/definitions/email_address" },
+            "STATE": { "enum": [ "REJECT" ] }
+          }
+        },
+        "affects": {
+          "not": {}
+        },
+        "description": {
+          "type": "object",
+          "required": [ "description_data" ],
+          "properties": {
+            "description_data": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/lang_string" }
+            }
+          }
+        },
+        "problemtype": {
+          "not": {}
+        },
+        "references": {
+          "not": {}
         }
       }
     }
-  }
+  ]
 }
-

--- a/cve_json_schema/CVE_JSON_4.0_min.schema
+++ b/cve_json_schema/CVE_JSON_4.0_min.schema
@@ -42,7 +42,7 @@
         "url": {
           "maxLength": 500,
           "type": "string",
-          "pattern": "^(ftp|http)s?://[^ \t]+$"
+          "pattern": "^(ftp|http)s?://\\S+$"
         }
       }
     },


### PR DESCRIPTION
Related to #53, this provides a single schema to validate CVE JSON files that have a state of RESERVED, REJECT, or PUBLIC.