### PR TITLE
- Required lang value to be three characters.

### DIFF
--- a/cve_json_schema/CVE_JSON_4.0_min_public.schema
+++ b/cve_json_schema/CVE_JSON_4.0_min_public.schema
@@ -49,7 +49,7 @@
       "type": "object",
       "required": [ "lang", "value" ],
       "properties": {
-        "lang": { "type": "string" },
+        "lang": { "type": "string", "minLength": 3, "maxLength": 3 },
         "value": { "type": "string", "maxLength": 3999 }
       }
     }


### PR DESCRIPTION
MITRE has seen some pull requests in which a two-character value for the "lang" string was used. The 4.0 draft schema says it should be an ISO 639-2 string, which means three characters, and this update enforces that.