### PR TITLE
never exit w/a 0 status code if any excepts caught

### DIFF
--- a/tools/cmdlinejsonvalidator.py
+++ b/tools/cmdlinejsonvalidator.py
@@ -42,7 +42,7 @@ def jsonvalidation(json_doc_path, json_schema_path):
         except ValueError as err:
             sys.stderr.write("Failed to parse JSON : \n")
             sys.stderr.write("  " + str(err) + "\n")
-            raise SystemExit
+            raise SystemExit(1)
 
     try:
         validate(json_doc, schema_doc)
@@ -53,7 +53,7 @@ def jsonvalidation(json_doc_path, json_schema_path):
         for error in errors:
             sys.stderr.write("Record did not pass: \n")
             sys.stderr.write(str(error.message) + "\n")
-
+        raise SystemExit(2)
 
 def main():
     import argparse


### PR DESCRIPTION
I was trying to iterate over files and use the exit code from this script to find out if my json files were valid, however I realized the script always returns 0. Even if the json is unparseable, `raise SystemExit` on L45 implicitly exits w/0 and in the case of an actual failed validation, no exceptions are raised and so the script exits w/a 0. This change, I think, let's the user distinguish between a good validation (0), an unparseable json file (1), and a failed validation (2). I was going to try and make the status code equal to the failed line number in the latter case, but that's beyond my skill and patience at the moment.

Obviously any other error values could be used, and `sys.exit(1)` could also be used instead of the `raise`, but they do the same thing and sys is already a dependency