### PR TITLE
Set a roomier URL maxlength

### DIFF
--- a/cve_json_schema/v5.x_discuss/cve505_consolidated.schema
+++ b/cve_json_schema/v5.x_discuss/cve505_consolidated.schema
@@ -12,7 +12,7 @@
             ],
             "properties": {
                 "url": {
-                    "maxLength": 500,
+                    "maxLength": 2000,
                     "type": "string",
                     "pattern": "^(ftp|http)s?://\\S+$"
                 }

--- a/cve_json_schema/v5.x_discuss/cve505_containerized.schema
+++ b/cve_json_schema/v5.x_discuss/cve505_containerized.schema
@@ -12,7 +12,7 @@
             ],
             "properties": {
                 "url": {
-                    "maxLength": 500,
+                    "maxLength": 2000,
                     "type": "string",
                     "pattern": "^(ftp|http)s?://\\S+$"
                 }


### PR DESCRIPTION
Fun fact, there is no reasonably-spec'ed maximum length to URLs, but there are some practical constraints thanks to Internet Explorer.

I do worry that 500 characters is a little bit too short for some cases, especially if a public reference is buried down in some technical documentation rabbit hole of sub-sub-sub directories on a domain that's near the legal DNS limit of 253 characters and is deeplinked to an anchor tag.

Okay, I'm having trouble coming up with a sensible URL that's more than 500 characters, so I don't have a great example on hand. But hey, it's not this JSON's job to be a URL length fascist.