### PR TITLE
Optional module, programFile, programRoutine, versionName

### DIFF
--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -130,7 +130,7 @@
             },
             "programRoutine": {
                "type": "string",
-               "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional)."
+               "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional).",
                "minLength": 1
             },
             "package_name": {

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -133,8 +133,8 @@
                "description": "A list of the affected source code files (optional)",
                "uniqueItems": true,
                "items": {
-                  "type": "string",
-                  "description": "Name of the affected source code file (optional)",
+                  "type": "uri",
+                  "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
                   "minLength": 1
                }
             },
@@ -201,9 +201,9 @@
                      "version_value"
                   ],
                   "properties": {
-                     "versionName": {
+                     "versionGroup": {
                         "type": "string",
-                        "description": "A name of the version branch, group, or a major version (e.g. 10.0, 3.1.*) where all version values are typically sequential or version_affected comparisons are meaningful (optional).",
+                        "description": "A string that represents a version branch, group, or a major version (e.g. 10.0, 3.1.*) where all version values are typically sequential or versionAffected comparisons are meaningful (optional).",
                         "minLength": 1
                      },                     
                      "version_value": {

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -131,7 +131,7 @@
             "programRoutine": {
                "type": "string",
                "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional)."
-               "minLength":1
+               "minLength": 1
             },
             "package_name": {
                "type": "string",

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -118,20 +118,35 @@
                "description": "Name of the affected product.",
                "minLength": 1
             },
-            "module": {
-               "type": "string",
-               "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
-               "minLength": 1
+            "modules": {
+               "type": "array",
+               "description": "A list of the affected components, features, modules, sub-components, sub-products, APIs, commands, utilities, programs, or functionalities (optional)",
+               "uniqueItems": true,
+               "items": {
+                  "type": "string",
+                  "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
+                  "minLength": 1
+               }
             },
-            "programFile": {
-               "type": "string",
-               "description": "Name of the affected source code file (optional)",
-               "minLength": 1
+            "programFiles": {
+               "type": "array",
+               "description": "A list of the affected source code files (optional)",
+               "uniqueItems": true,
+               "items": {
+                  "type": "string",
+                  "description": "Name of the affected source code file (optional)",
+                  "minLength": 1
+               }
             },
-            "programRoutine": {
-               "type": "string",
-               "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional).",
-               "minLength": 1
+            "programRoutines": {
+               "type": "array",
+               "description": "A list of the affected source code functions, methods, subroutines, or procedures (optional).",
+               "uniqueItems": true,
+               "items": {
+                  "type": "string",
+                  "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional).",
+                  "minLength": 1
+               }
             },
             "package_name": {
                "type": "string",

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -120,7 +120,7 @@
             },
             "module": {
                "type": "string",
-               "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional)."
+               "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
                "minLength": 1
             },
             "programFile": {

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -118,6 +118,21 @@
                "description": "Name of the affected product.",
                "minLength": 1
             },
+            "module": {
+               "type": "string",
+               "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional)."
+               "minLength":1
+            },
+            "programFile": {
+               "type": "string",
+               "description": "Name of the affected source code file (optional)"
+               "minLength":1
+            },
+            "programRoutine": {
+               "type": "string",
+               "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional)."
+               "minLength":1
+            },
             "package_name": {
                "type": "string",
                "description": "Name of the affected software package, if it exists.",
@@ -171,9 +186,14 @@
                      "version_value"
                   ],
                   "properties": {
+                     "versionName": {
+                        "type": "string",
+                        "description": "A name of the version branch, group, or a major version (e.g. 10.0, 3.1.*), where all version values are typically sequential or version_affected comparions are meaningful (optional).",
+                        "minLength": 1
+                     },                     
                      "version_value": {
                         "type": "string",
-                        "description": "The version name/value (e.g. 10.0, 3.1, \"IceHouse\")",
+                        "description": "The version name/value (e.g. 10.0.1, 3.1.2, \"IceHouse\")",
                         "minLength": 1
                      },
                      "version_affected": {

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -126,7 +126,7 @@
             "programFile": {
                "type": "string",
                "description": "Name of the affected source code file (optional)"
-               "minLength":1
+               "minLength": 1
             },
             "programRoutine": {
                "type": "string",

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -121,7 +121,7 @@
             "module": {
                "type": "string",
                "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional)."
-               "minLength":1
+               "minLength": 1
             },
             "programFile": {
                "type": "string",

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -125,7 +125,7 @@
             },
             "programFile": {
                "type": "string",
-               "description": "Name of the affected source code file (optional)"
+               "description": "Name of the affected source code file (optional)",
                "minLength": 1
             },
             "programRoutine": {

--- a/cve_json_schema/v5.x_discuss/cve513.schema
+++ b/cve_json_schema/v5.x_discuss/cve513.schema
@@ -188,7 +188,7 @@
                   "properties": {
                      "versionName": {
                         "type": "string",
-                        "description": "A name of the version branch, group, or a major version (e.g. 10.0, 3.1.*), where all version values are typically sequential or version_affected comparions are meaningful (optional).",
+                        "description": "A name of the version branch, group, or a major version (e.g. 10.0, 3.1.*) where all version values are typically sequential or version_affected comparisons are meaningful (optional).",
                         "minLength": 1
                      },                     
                      "version_value": {


### PR DESCRIPTION
Useful ideas from https://github.com/ossf/wg-vulnerability-disclosures/issues/53 + versionName for identifying version branches.

CVEs in large open source projects may benefit from improved accuracy of specifying where the vulnerability is in an automation friendly machine readable format.
For example
 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0313 

productName = "Linux Kernel"
modules = [ "Extended Verification Module (EVM)" ]
programFiles = [ "security/integrity/evm/evm_crypto.c" ]
programRoutines = [ "evm_update_evmxattr" ]


